### PR TITLE
fix: allow only uuid 0.7

### DIFF
--- a/postgres-shared/Cargo.toml
+++ b/postgres-shared/Cargo.toml
@@ -29,4 +29,4 @@ geo = { version = "0.4", optional = true }
 rustc-serialize = { version = "0.3", optional = true }
 serde_json = { version = "1.0", optional = true }
 time = { version = "0.1.14", optional = true }
-uuid = { version = ">=0.5, <0.8", optional = true }
+uuid = { version = "0.7", optional = true }

--- a/postgres-shared/src/types/uuid.rs
+++ b/postgres-shared/src/types/uuid.rs
@@ -9,7 +9,7 @@ use types::{FromSql, ToSql, Type, IsNull, UUID};
 impl FromSql for Uuid {
     fn from_sql(_: &Type, raw: &[u8]) -> Result<Uuid, Box<Error + Sync + Send>> {
         let bytes = types::uuid_from_sql(raw)?;
-        Ok(Uuid::from_bytes(&bytes).unwrap())
+        Ok(Uuid::from_slice(&bytes).unwrap())
     }
 
     accepts!(UUID);


### PR DESCRIPTION
Turns out it breaks with uuid 0.7. No luck with supporting a range